### PR TITLE
fix: QnA-db-answers-constraint

### DIFF
--- a/supabase/migrations/20240506062803_fix_QnA_validation.sql
+++ b/supabase/migrations/20240506062803_fix_QnA_validation.sql
@@ -1,0 +1,9 @@
+alter table "public"."answers" add constraint "choice_range_constraint" CHECK (((choice >= 0) AND (choice <= 3))) not valid;
+
+alter table "public"."answers" validate constraint "choice_range_constraint";
+
+alter table "public"."questions" add constraint "exact_answers_length" CHECK ((array_length(answers, 1) = 4)) not valid;
+
+alter table "public"."questions" validate constraint "exact_answers_length";
+
+


### PR DESCRIPTION
**Changes Made:**

**answers Table:**

- Added a constraint named `choice_range_constraint` to ensure that the choice column values fall within a specified range (0 to 3).
- Validated the `choice_range_constraint` constraint to enforce its rules.

**questions Table:**

- Added a constraint named `exact_answers_length` to verify that the answers array contains exactly four elements.
- Validated the `exact_answers_length` constraint to enforce its rules.